### PR TITLE
Assuming .strings files are UTF-8 encoded

### DIFF
--- a/frameit/lib/frameit/strings_parser.rb
+++ b/frameit/lib/frameit/strings_parser.rb
@@ -7,8 +7,8 @@ module Frameit
 
       result = {}
 
-      # A .strings file is UTF-16 encoded. We only want to deal with UTF-8
-      content = `iconv -f UTF-16 -t UTF-8 '#{path}' 2>&1`
+      # Our .strings files are UTF-8 encoded, so we don't need to convert
+      content = `cat '#{path}' 2>&1`
 
       content.split("\n").each_with_index do |line, index|
         begin


### PR DESCRIPTION
`frameit` previously assumed they were UTF-16 encoded, but UTF-8 encoded files are much easier to work with and the default of most text editors

🍎 iOS: quizlet/ios-release-metadata/pull/5 converted the few iOS .strings files that were UTF-16 encoded to UTF-8, so iOS's are now all UTF-8
🤖 Android: cc @brandonchinn for a heads up that https://quizlet.slack.com/archives/C0KFLVAKV/p1518137852000191 is now happening